### PR TITLE
feat: add lambda application deploy schema to nestjs-golden-path

### DIFF
--- a/json-schema/nestjs-goldenpath/config/application/lambda-application-config.schema.json
+++ b/json-schema/nestjs-goldenpath/config/application/lambda-application-config.schema.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://raw.githubusercontent.com/ageras-com/schema-collection/v1/json-schema/nestjs-goldenpath/config/application/lambda-application-config.schema.json#",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["lambda"],
+      "description": "The workload type of the application."
+    },
+    "lambda": {
+      "type": "object",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "$ref": "https://raw.githubusercontent.com/ageras-com/schema-collection/v1/json-schema/nestjs-goldenpath/config/workload/lambda-config.schema.json#",
+              "description": "The default Lambda configuration."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "patternProperties": {
+            "^[_a-zA-Z][a-zA-Z0-9_-]*$": {
+              "$ref": "https://raw.githubusercontent.com/ageras-com/schema-collection/v1/json-schema/nestjs-goldenpath/config/workload/lambda-config.schema.json#",
+              "description": "The environment Lambda configuration that overrides the default configuration."
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false,
+      "required": ["default"]
+    }
+  },
+  "required": ["type", "lambda"]
+}

--- a/json-schema/nestjs-goldenpath/config/config.schema.json
+++ b/json-schema/nestjs-goldenpath/config/config.schema.json
@@ -20,6 +20,9 @@
       "oneOf": [
         {
           "$ref": "https://raw.githubusercontent.com/ageras-com/schema-collection/v1/json-schema/nestjs-goldenpath/config/application/ecs-application-config.schema.json#"
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/ageras-com/schema-collection/v1/json-schema/nestjs-goldenpath/config/application/lambda-application-config.schema.json#"
         }
       ]
     }

--- a/json-schema/nestjs-goldenpath/config/workload/lambda-config.schema.json
+++ b/json-schema/nestjs-goldenpath/config/workload/lambda-config.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "https://raw.githubusercontent.com/ageras-com/schema-collection/v1/json-schema/nestjs-goldenpath/config/workload/lambda-config.schema.json#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "arn": {
+      "type": "string",
+      "description": "The ARN of the Lambda function."
+    },
+    "region": {
+      "type": "string",
+      "description": "The AWS region where the Lambda function is deployed."
+    },
+    "cluster": {
+      "type": "string",
+      "description": "The name of the Lambda cluster."
+    },
+    "service": {
+      "type": "string",
+      "description": "The name of the Lambda function."
+    },
+    "task-definition": {
+      "type": "string",
+      "description": "The name of the Lambda task definition."
+    },
+    "container-name": {
+      "type": "string",
+      "description": "The name of the container within the Lambda task."
+    }
+  }
+}


### PR DESCRIPTION
Add lambda deploy config schema in nestjs-golden-path.

It's really similar to the ECS deploy config.