### PR TITLE
fix: required properties for application config schema

### DIFF
--- a/json-schema/nestjs-goldenpath/config/application/ecs-application-config.schema.json
+++ b/json-schema/nestjs-goldenpath/config/application/ecs-application-config.schema.json
@@ -15,8 +15,7 @@
           "description": "The environment ECS configuration that overrides the default configuration."
         }
       },
-      "minProperties": 1,
-      "unevaluatedProperties": false
+      "minProperties": 1
     }
   },
   "required": ["type", "ecs"]

--- a/json-schema/nestjs-goldenpath/config/application/lambda-application-config.schema.json
+++ b/json-schema/nestjs-goldenpath/config/application/lambda-application-config.schema.json
@@ -15,8 +15,7 @@
           "description": "The environment Lambda configuration that overrides the default configuration."
         }
       },
-      "minProperties": 1,
-      "unevaluatedProperties": false
+      "minProperties": 1
     }
   },
   "required": ["type", "lambda"]


### PR DESCRIPTION
Previous usage of `unuevaluatedProperties` results in errors during schema validation. Removing it as it's incompatible with out last schema changes in #11 