### PR TITLE
feat: remove registry config requirement in deploy cfg

### DIFF
--- a/json-schema/nestjs-goldenpath/config/config.schema.json
+++ b/json-schema/nestjs-goldenpath/config/config.schema.json
@@ -28,5 +28,5 @@
     }
   ],
   "unevaluatedProperties": false,
-  "required": ["name", "description", "environments", "registry", "type"]
+  "required": ["name", "description", "environments", "type"]
 }


### PR DESCRIPTION
For lambdas we don't need image builds; this PR removes registry config requirement on each deployment config consequently.