### PR TITLE
feat: add port in migrations-db-rds schema

### DIFF
--- a/json-schema/nestjs-goldenpath/config/migrations/migrations-db-rds.schema.json
+++ b/json-schema/nestjs-goldenpath/config/migrations/migrations-db-rds.schema.json
@@ -35,6 +35,10 @@
           "type": "string",
           "description": "The database schema to use for migrations."
         },
+        "port": {
+          "type": "number",
+          "description": "The database port to use for migrations."
+        },
         "username_ref": {
           "type": "string",
           "description": "Reference to the secret containing the database username."


### PR DESCRIPTION
We want to be able to override default port to run migrations on DB.