### PR TITLE
feat(#EE-804): rewrite sync-catalog-context as plain .mjs

### DIFF
--- a/.github/workflows/sync-catalog-context.yml
+++ b/.github/workflows/sync-catalog-context.yml
@@ -1,0 +1,93 @@
+name: Sync catalog-context
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # weekly, Monday 08:00 UTC
+  repository_dispatch:
+    types: [catalog-context-release]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Download and diff, but do not open a PR
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sync:
+    name: Sync canonical values from catalog-context
+    runs-on: ubuntu-latest
+    steps:
+      - name: GCP Authentication
+        uses: shinetools/github-actions/gcp/authentication@v1
+
+      - id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@v3
+        with:
+          secrets: |-
+            RELEASE_PLEASE_KEY_BASE64:shine-internal-2364/SHINE_RELEASE_PLEASE_GITHUB_APP_PRIVATE_KEY_BASE64
+
+      - id: decode-private-key
+        shell: bash
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "RELEASE_PLEASE_KEY<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "${{ steps.secrets.outputs.RELEASE_PLEASE_KEY_BASE64 }}" | base64 --decode | while IFS= read -r line; do
+            echo "::add-mask::$line"
+            echo "$line" >> "$GITHUB_OUTPUT"
+          done
+          echo "$EOF" >> "$GITHUB_OUTPUT"
+
+      - id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: Iv23liRRqGvmap67S5KI
+          private-key: ${{ steps.decode-private-key.outputs.RELEASE_PLEASE_KEY }}
+          owner: ageras-com
+          repositories: schema-collection,catalog-context
+
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Download catalog-context schema assets
+        run: |
+          mkdir -p /tmp/catalog-context
+          gh release download \
+            --repo ageras-com/catalog-context \
+            --pattern '*.schema.json' \
+            --dir /tmp/catalog-context/
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Sync canonical values from catalog-context
+        run: node scripts/sync-catalog-context.mjs /tmp/catalog-context/
+
+      - name: Open or update sync PR
+        if: ${{ !inputs.dry-run }}
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/sync-catalog-context
+          base: main
+          commit-message: "chore: sync canonical values from catalog-context"
+          title: "chore: sync canonical values from catalog-context"
+          delete-branch: false
+          labels: automated, schema-sync
+          body: |
+            Automated sync of canonical enum values from the latest [catalog-context](https://github.com/ageras-com/catalog-context) release.
+
+            **Files updated:**
+            - `partials/spec-defaults.schema.json` — `lifecycle` and `tier` enums
+            - `partials/extensions-defaults.schema.json` — `domain` enum, flat `area` enum, domain→area `allOf`
+            - `partials/tags-defaults.schema.json` — `domain:<value>` and `area:<value>` tag mirroring blocks
+            - `service.schema.json` — service `type` enum
+
+            ⚠️ **Potentially breaking.** Any entity whose enum value was removed from
+            catalog-context will start failing validation once this merges and releases.
+            Review the diff before merging.

--- a/scripts/sync-catalog-context.mjs
+++ b/scripts/sync-catalog-context.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const [, , schemasDir] = process.argv;
+if (!schemasDir) {
+  console.error('Usage: sync-catalog-context.mjs <schemas-dir>');
+  process.exit(1);
+}
+
+const catalogRoot = path.join(__dirname, '..', 'json-schema', 'datadog-catalog', 'v3');
+
+function readSource(name) {
+  const file = path.join(schemasDir, name);
+  if (!fs.existsSync(file)) throw new Error(`Source file not found: ${file}`);
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function readTarget(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(catalogRoot, relPath), 'utf8'));
+}
+
+function writeTarget(relPath, obj) {
+  fs.writeFileSync(path.join(catalogRoot, relPath), JSON.stringify(obj, null, 2) + '\n');
+  console.log(`  updated ${relPath}`);
+}
+
+function main() {
+  const tierSrc = readSource('tier.schema.json');
+  const lifecycleSrc = readSource('lifecycle.schema.json');
+  const domainSrc = readSource('domain.schema.json');
+  const serviceTypeSrc = readSource('service-type.schema.json');
+
+  const domainEnum = domainSrc.properties.domain.enum;
+  const domainAreas = {};
+  for (const block of domainSrc.allOf) {
+    const d = block.if?.properties?.domain?.const;
+    const areas = block.then?.properties?.area?.enum;
+    if (d && areas) domainAreas[d] = areas;
+  }
+  const allAreas = domainEnum.flatMap(d => domainAreas[d] ?? []);
+
+  {
+    const schema = readTarget('partials/spec-defaults.schema.json');
+    schema.properties.lifecycle.enum = lifecycleSrc.enum;
+    schema.properties.tier.enum = tierSrc.enum;
+    writeTarget('partials/spec-defaults.schema.json', schema);
+  }
+
+  {
+    const schema = readTarget('partials/extensions-defaults.schema.json');
+    schema.properties.domain.enum = domainEnum;
+    schema.properties.area.enum = allAreas;
+    schema.allOf = domainEnum.map(d => ({
+      if: { required: ['domain'], properties: { domain: { const: d } } },
+      then: { properties: { area: { enum: domainAreas[d] ?? [] } } },
+    }));
+    writeTarget('partials/extensions-defaults.schema.json', schema);
+  }
+
+  {
+    const schema = readTarget('partials/tags-defaults.schema.json');
+    schema.allOf = [
+      ...domainEnum.map(d => ({
+        if: {
+          required: ['extensions'],
+          properties: { extensions: { required: ['domain'], properties: { domain: { const: d } } } },
+        },
+        then: {
+          required: ['metadata'],
+          properties: {
+            metadata: {
+              required: ['tags'],
+              properties: { tags: { contains: { const: `domain:${d}` } } },
+            },
+          },
+        },
+      })),
+      ...allAreas.map(a => ({
+        if: {
+          required: ['extensions'],
+          properties: { extensions: { required: ['area'], properties: { area: { const: a } } } },
+        },
+        then: {
+          required: ['metadata'],
+          properties: {
+            metadata: {
+              required: ['tags'],
+              properties: { tags: { contains: { const: `area:${a}` } } },
+            },
+          },
+        },
+      })),
+    ];
+    writeTarget('partials/tags-defaults.schema.json', schema);
+  }
+
+  {
+    const schema = readTarget('service.schema.json');
+    const specAllOf = schema.allOf?.[1]?.properties?.spec?.allOf;
+    if (!specAllOf)
+      throw new Error(
+        'Unexpected service.schema.json structure: missing allOf[1].properties.spec.allOf',
+      );
+    const typeBlock = specAllOf.find(b => b.properties?.type !== undefined);
+    if (!typeBlock) throw new Error('Cannot locate type.enum in service.schema.json spec.allOf');
+    typeBlock.properties.type.enum = serviceTypeSrc.enum;
+    writeTarget('service.schema.json', schema);
+  }
+
+  console.log('Sync complete.');
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err.message ?? err);
+  process.exit(1);
+}


### PR DESCRIPTION
Converts `scripts/sync-catalog-context.ts` to a dependency-free `.mjs` script, removing the need for `tsx`, `typescript`, `package.json`, and `tsconfig.json`. Aligns the workflow with catalog-context conventions (action versions, node 24, consolidated secrets step, dry-run input).

Closes EE-808

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI that authenticates via GitHub App secrets and can open automated PRs updating validation enums. The rewrite itself is straightforward tooling, but mis-syncs could produce breaking schema changes.
> 
> **Overview**
> Rewrites the catalog-context sync as a **dependency-free** `scripts/sync-catalog-context.mjs`, so it runs with plain `node` and no longer needs `tsx`/TypeScript tooling.
> 
> The workflow now downloads the latest `*.schema.json` release assets from `catalog-context`, runs the sync into Datadog catalog v3 partials/`service.schema.json`, and opens or updates an automated PR. It also adds a **dry-run** input, Node 24, and consolidated secrets/app-token steps aligned with catalog-context conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02bd884323af65364a06f5173b280399db7c41b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->