### PR TITLE
feat: add accounting-core area

### DIFF
--- a/json-schema/datadog-catalog/v3/partials/extensions-defaults.schema.json
+++ b/json-schema/datadog-catalog/v3/partials/extensions-defaults.schema.json
@@ -21,6 +21,7 @@
         "accounting-advisors",
         "accounting-preaccounting",
         "accounting-invoicing",
+        "accounting-core",
         "banking-customer-lifecycle",
         "banking-experience",
         "banking-foundations",
@@ -56,7 +57,8 @@
             "enum": [
               "accounting-advisors",
               "accounting-preaccounting",
-              "accounting-invoicing"
+              "accounting-invoicing",
+              "accounting-core"
             ]
           }
         }

--- a/json-schema/datadog-catalog/v3/partials/tags-defaults.schema.json
+++ b/json-schema/datadog-catalog/v3/partials/tags-defaults.schema.json
@@ -321,6 +321,44 @@
             ],
             "properties": {
               "area": {
+                "const": "accounting-core"
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "metadata"
+        ],
+        "properties": {
+          "metadata": {
+            "required": [
+              "tags"
+            ],
+            "properties": {
+              "tags": {
+                "contains": {
+                  "const": "area:accounting-core"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "extensions"
+        ],
+        "properties": {
+          "extensions": {
+            "required": [
+              "area"
+            ],
+            "properties": {
+              "area": {
                 "const": "banking-customer-lifecycle"
               }
             }


### PR DESCRIPTION
## WHAT
Adds `accounting-core` as a valid `extensions.area` value for the `accounting` domain, in `extensions-defaults.schema.json` and the corresponding tag-mirroring rule in `tags-defaults.schema.json`.

## WHY
Mirrors [ageras-com/catalog-context#17](https://github.com/ageras-com/catalog-context/pull/17) (not merged yet). This repo hand-duplicates `catalog-context`'s domain/area enum rather than generating it from there — `EE-804` tracks wiring that up — so the value needs adding here separately before any entity can actually use it.

Additive, not a rename: `accounting-invoicing` stays valid, since it's still used as a live default tag in `billysbilling/infrastructure` and `Zervant/terraform`.

Blocks [billysbilling/billy-api#4115](https://github.com/billysbilling/billy-api/pull/4115), which needs `accounting-core` to correctly tag a cross-area monolith.

Verified locally with `check-jsonschema` against both edited partials directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON Schema enum expansion only; existing areas remain valid and no runtime or auth logic is touched.
> 
> **Overview**
> Adds **`accounting-core`** as a valid `extensions.area` under the `accounting` domain.
> 
> Updates `extensions-defaults.schema.json` (global area enum + accounting-domain constraint) and adds the matching tag-mirroring rule in `tags-defaults.schema.json` so entities using the new area must include `area:accounting-core` in `metadata.tags`. Existing areas such as `accounting-invoicing` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1defd2a57314040523f5f0ed6faf7f34325136d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->