### PR TITLE
fix: update pipeline actions to support node 24 (EE-575)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
         with:
           release-type: simple
           target-branch: main
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Tag major if release created
         if: ${{ steps.release-please.outputs.release_created }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only dependency version bumps with no application or release-script logic changes.
> 
> **Overview**
> Updates the **schema collection release** workflow (`.github/workflows/release.yml`) so GitHub Actions dependencies align with Node 24–compatible versions (EE-575).
> 
> **`googleapis/release-please-action`** is bumped from floating `@v4` to a pinned commit for **v5.0.0**. **`actions/checkout`** moves from `@v4` to a pinned commit for **v7.0.1**. Release behavior (release-please config, major/minor tagging shell steps) is unchanged—only action versions and SHA pinning differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eba7fef596f86b78c2acd39b486c5cc42f157605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->